### PR TITLE
acuvim_l: [feat] add device models for Accuenergy Acuvim-L series meters

### DIFF
--- a/src/xeto/cc.accuenergy.acuvim_l/acuvim_l-1LN-1LL-3LN.xeto
+++ b/src/xeto/cc.accuenergy.acuvim_l/acuvim_l-1LN-1LL-3LN.xeto
@@ -1,0 +1,62 @@
+//
+// Copyright (c) 2026, Project-Haystack
+// Licensed under the Academic Free License version 3.0
+//
+// History:
+//   14 Jul 2026  Trevor Adelman  Creation
+//
+
+// Device model for Accuenergy's Acuvim-L Series Power Meter (1LN, 1LL, 3LN,
+// or 3LN-2.5 wiring). In these wiring modes the voltage THD registers report
+// phase voltage THD.
+AcuvimLElecAc1LNOr1LLOr3LNMeter : AcuvimLElecAcMeter <abstract> {
+  points: {
+    ElecAcPhaseQualityVoltageSensor {
+      totalHarmonicDistortion
+      phase: "L1"
+      modbusAddr: ModbusAddr { addr: "416475", encoding: "s2", scale: "*0.01", dis: "THD_V1" }
+      bacnetAddr: BacnetAddr { addr: "AI64", dis: "Phase A Voltage THD" }
+    }
+    ElecAcPhaseQualityVoltageSensor {
+      totalHarmonicDistortion
+      phase: "L2"
+      modbusAddr: ModbusAddr { addr: "416476", encoding: "s2", scale: "*0.01", dis: "THD_V2" }
+      bacnetAddr: BacnetAddr { addr: "AI65", dis: "Phase B Voltage THD" }
+    }
+    ElecAcPhaseQualityVoltageSensor {
+      totalHarmonicDistortion
+      phase: "L3"
+      modbusAddr: ModbusAddr { addr: "416477", encoding: "s2", scale: "*0.01", dis: "THD_V3" }
+      bacnetAddr: BacnetAddr { addr: "AI66", dis: "Phase C Voltage THD" }
+    }
+    ElecAcLAvgQualityVoltageSensor {
+      totalHarmonicDistortion
+      modbusAddr: ModbusAddr { addr: "416478", encoding: "s2", scale: "*0.01", dis: "THD_avg" }
+      bacnetAddr: BacnetAddr { addr: "AI67", dis: "Average Voltage THD" }
+    }
+  }
+}
+
+// Device model for Accuenergy's Acuvim-L Series Power Meter configured to
+// use 3 line-to-neutral voltage channels.
+AcuvimLElecAc3LNMeter : AcuvimLElecAc1LNOr1LLOr3LNMeter & ElecAc3LNMeter <abstract>
+
+// Device model for Accuenergy's Acuvim-L Series Power Meter configured to
+// use 1 line-to-neutral voltage channel.
+AcuvimLElecAc1LNMeter : AcuvimLElecAc1LNOr1LLOr3LNMeter & ElecAc1LNMeter <abstract>
+
+// Device model for Accuenergy's Acuvim-L Series Power Meter configured to
+// use 1 line-to-line voltage channel.
+AcuvimLElecAc1LLMeter : AcuvimLElecAc1LNOr1LLOr3LNMeter & ElecAc1LLMeter <abstract>
+
+// Device model for Accuenergy's Acuvim-EL Power Meter configured to
+// use 3 line-to-neutral voltage channels.
+AcuvimELElecAc3LNMeter : AcuvimLElecAc3LNMeter
+
+// Device model for Accuenergy's Acuvim-EL Power Meter configured to
+// use 1 line-to-neutral voltage channel.
+AcuvimELElecAc1LNMeter : AcuvimLElecAc1LNMeter
+
+// Device model for Accuenergy's Acuvim-EL Power Meter configured to
+// use 1 line-to-line voltage channel.
+AcuvimELElecAc1LLMeter : AcuvimLElecAc1LLMeter

--- a/src/xeto/cc.accuenergy.acuvim_l/acuvim_l-2LL-3LL.xeto
+++ b/src/xeto/cc.accuenergy.acuvim_l/acuvim_l-2LL-3LL.xeto
@@ -1,0 +1,54 @@
+//
+// Copyright (c) 2026, Project-Haystack
+// Licensed under the Academic Free License version 3.0
+//
+// History:
+//   14 Jul 2026  Trevor Adelman  Creation
+//
+
+// Device model for Accuenergy's Acuvim-L Series Power Meter (2LL or 3LL
+// wiring). In these wiring modes the voltage THD registers report line to
+// line voltage THD: 405AH=V12, 405BH=V31, 405CH=V23 (Table 6-27).
+AcuvimLElecAc2LLOr3LLMeter : AcuvimLElecAcMeter <abstract> {
+  points: {
+    ElecAcPhaseQualityVoltageSensor {
+      totalHarmonicDistortion
+      phase: "L1-L2"
+      modbusAddr: ModbusAddr { addr: "416475", encoding: "s2", scale: "*0.01", dis: "THD_V12" }
+      bacnetAddr: BacnetAddr { addr: "AI64", dis: "Phase A Voltage THD" }
+    }
+    ElecAcPhaseQualityVoltageSensor {
+      totalHarmonicDistortion
+      phase: "L3-L1"
+      modbusAddr: ModbusAddr { addr: "416476", encoding: "s2", scale: "*0.01", dis: "THD_V31" }
+      bacnetAddr: BacnetAddr { addr: "AI65", dis: "Phase B Voltage THD" }
+    }
+    ElecAcPhaseQualityVoltageSensor {
+      totalHarmonicDistortion
+      phase: "L2-L3"
+      modbusAddr: ModbusAddr { addr: "416477", encoding: "s2", scale: "*0.01", dis: "THD_V23" }
+      bacnetAddr: BacnetAddr { addr: "AI66", dis: "Phase C Voltage THD" }
+    }
+    ElecAcLLAvgQualityVoltageSensor {
+      totalHarmonicDistortion
+      modbusAddr: ModbusAddr { addr: "416478", encoding: "s2", scale: "*0.01", dis: "THD_avg" }
+      bacnetAddr: BacnetAddr { addr: "AI67", dis: "Average Voltage THD" }
+    }
+  }
+}
+
+// Device model for Accuenergy's Acuvim-L Series Power Meter configured to
+// use 3 line-to-line voltage channels.
+AcuvimLElecAc3LLMeter : AcuvimLElecAc2LLOr3LLMeter & ElecAc3LLMeter <abstract>
+
+// Device model for Accuenergy's Acuvim-L Series Power Meter configured to
+// use 2 line-to-line voltage channels.
+AcuvimLElecAc2LLMeter : AcuvimLElecAc2LLOr3LLMeter & ElecAc2LLMeter <abstract>
+
+// Device model for Accuenergy's Acuvim-EL Power Meter configured to
+// use 3 line-to-line voltage channels.
+AcuvimELElecAc3LLMeter : AcuvimLElecAc3LLMeter
+
+// Device model for Accuenergy's Acuvim-EL Power Meter configured to
+// use 2 line-to-line voltage channels.
+AcuvimELElecAc2LLMeter : AcuvimLElecAc2LLMeter

--- a/src/xeto/cc.accuenergy.acuvim_l/acuvim_l.xeto
+++ b/src/xeto/cc.accuenergy.acuvim_l/acuvim_l.xeto
@@ -1,0 +1,341 @@
+//
+// Copyright (c) 2026, Project-Haystack
+// Licensed under the Academic Free License version 3.0
+//
+// History:
+//   22 Jun 2026  Trevor Adelman  Creation
+//   14 Jul 2026  Trevor Adelman  Restructure for wiring configs and verify registers
+//
+
+// Device model for Accuenergy's Acuvim-L Series Power Meter
+AcuvimLElecAcMeter : AcElecMeter <abstract> {
+  resources: Query {
+    PdfFile {
+      dis: "Acuvim-L Multifunction Power and Energy Meter User Manual"
+      uri: "https://www.accuenergy.com/wp-content/uploads/Acuvim-L-Multifunction-Power-and-Energy-Meter-User-Manual-v4.pdf"
+    }
+  }
+  attrs: Query {
+    ManufacturerAttr { val: "Accuenergy" }
+    ModelSeriesAttr { val: "Acuvim-L" }
+    DimensionLengthAttr { val: 96mm }
+    DimensionWidthAttr { val: 96mm }
+    DimensionHeightAttr { val: 64.3mm }
+    MinRatedOperatingTempAttr { val: -25°C }
+    MaxRatedOperatingTempAttr { val: 70°C }
+  }
+  points: {
+    ElecAcFreqSensor {
+      modbusAddr: ModbusAddr { addr: "408577", encoding: "f4", dis: "Frequency" }
+      bacnetAddr: BacnetAddr { addr: "AI1", dis: "Frequency" }
+    }
+    ElecAcPhaseRmsVoltageSensor {
+      phase: "L1"
+      modbusAddr: ModbusAddr { addr: "408579", encoding: "f4", dis: "Phase 1 Voltage" }
+      bacnetAddr: BacnetAddr { addr: "AI2", dis: "Phase A Voltage" }
+    }
+    ElecAcPhaseRmsVoltageSensor {
+      phase: "L2"
+      modbusAddr: ModbusAddr { addr: "408581", encoding: "f4", dis: "Phase 2 Voltage" }
+      bacnetAddr: BacnetAddr { addr: "AI3", dis: "Phase B Voltage" }
+    }
+    ElecAcPhaseRmsVoltageSensor {
+      phase: "L3"
+      modbusAddr: ModbusAddr { addr: "408583", encoding: "f4", dis: "Phase 3 Voltage" }
+      bacnetAddr: BacnetAddr { addr: "AI4", dis: "Phase C Voltage" }
+    }
+    ElecAcLAvgRmsVoltageSensor {
+      modbusAddr: ModbusAddr { addr: "408585", encoding: "f4", dis: "Average Phase Voltage" }
+      bacnetAddr: BacnetAddr { addr: "AI5", dis: "Average Phase Voltage" }
+    }
+    ElecAcPhaseRmsVoltageSensor {
+      phase: "L1-L2"
+      modbusAddr: ModbusAddr { addr: "408587", encoding: "f4", dis: "Line Voltage 1-2" }
+      bacnetAddr: BacnetAddr { addr: "AI6", dis: "Line Voltage AB" }
+    }
+    ElecAcPhaseRmsVoltageSensor {
+      phase: "L2-L3"
+      modbusAddr: ModbusAddr { addr: "408589", encoding: "f4", dis: "Line Voltage 2-3" }
+      bacnetAddr: BacnetAddr { addr: "AI7", dis: "Line Voltage BC" }
+    }
+    ElecAcPhaseRmsVoltageSensor {
+      phase: "L3-L1"
+      modbusAddr: ModbusAddr { addr: "408591", encoding: "f4", dis: "Line Voltage 3-1" }
+      bacnetAddr: BacnetAddr { addr: "AI8", dis: "Line Voltage CA" }
+    }
+    ElecAcLLAvgRmsVoltageSensor {
+      modbusAddr: ModbusAddr { addr: "408593", encoding: "f4", dis: "Average Line Voltage" }
+      bacnetAddr: BacnetAddr { addr: "AI9", dis: "Average Line Voltage" }
+    }
+    ElecAcPhaseUnsignedRmsCurrentSensor {
+      phase: "L1"
+      modbusAddr: ModbusAddr { addr: "408595", encoding: "f4", dis: "Total Phase A Current" }
+      bacnetAddr: BacnetAddr { addr: "AI10", dis: "Phase A Current" }
+    }
+    ElecAcPhaseUnsignedRmsCurrentSensor {
+      phase: "L2"
+      modbusAddr: ModbusAddr { addr: "408597", encoding: "f4", dis: "Total Phase B Current" }
+      bacnetAddr: BacnetAddr { addr: "AI11", dis: "Phase B Current" }
+    }
+    ElecAcPhaseUnsignedRmsCurrentSensor {
+      phase: "L3"
+      modbusAddr: ModbusAddr { addr: "408599", encoding: "f4", dis: "Total Phase C Current" }
+      bacnetAddr: BacnetAddr { addr: "AI12", dis: "Phase C Current" }
+    }
+    ElecAcLAvgUnsignedRmsCurrentSensor {
+      modbusAddr: ModbusAddr { addr: "408607", encoding: "f4", dis: "Average Current" }
+      bacnetAddr: BacnetAddr { addr: "AI13", dis: "Average Current" }
+    }
+    ElecAcNeutralUnsignedRmsCurrentSensor {
+      modbusAddr: ModbusAddr { addr: "408601", encoding: "f4", dis: "Neutral Current Calculated" }
+      bacnetAddr: BacnetAddr { addr: "AI14", dis: "Neutral Current" }
+    }
+    ElecAcPhaseNetActivePowerSensor {
+      phase: "L1"
+      modbusAddr: ModbusAddr { addr: "408609", encoding: "f4", scale: "*0.001", dis: "Phase A Power" }
+      bacnetAddr: BacnetAddr { addr: "AI15", dis: "Phase A Active Power" }
+    }
+    ElecAcPhaseNetActivePowerSensor {
+      phase: "L2"
+      modbusAddr: ModbusAddr { addr: "408611", encoding: "f4", scale: "*0.001", dis: "Phase B Power" }
+      bacnetAddr: BacnetAddr { addr: "AI16", dis: "Phase B Active Power" }
+    }
+    ElecAcPhaseNetActivePowerSensor {
+      phase: "L3"
+      modbusAddr: ModbusAddr { addr: "408613", encoding: "f4", scale: "*0.001", dis: "Phase C Power" }
+      bacnetAddr: BacnetAddr { addr: "AI17", dis: "Phase C Active Power" }
+    }
+    ElecAcTotalNetActivePowerSensor {
+      modbusAddr: ModbusAddr { addr: "408615", encoding: "f4", scale: "*0.001", dis: "Total System Power" }
+      bacnetAddr: BacnetAddr { addr: "AI18", dis: "Total Active Power" }
+    }
+    ElecAcPhaseNetReactivePowerSensor {
+      phase: "L1"
+      modbusAddr: ModbusAddr { addr: "408617", encoding: "f4", scale: "*0.001", dis: "Phase A Reactive Power" }
+      bacnetAddr: BacnetAddr { addr: "AI19", dis: "Phase A Reactive Power" }
+    }
+    ElecAcPhaseNetReactivePowerSensor {
+      phase: "L2"
+      modbusAddr: ModbusAddr { addr: "408619", encoding: "f4", scale: "*0.001", dis: "Phase B Reactive Power" }
+      bacnetAddr: BacnetAddr { addr: "AI20", dis: "Phase B Reactive Power" }
+    }
+    ElecAcPhaseNetReactivePowerSensor {
+      phase: "L3"
+      modbusAddr: ModbusAddr { addr: "408621", encoding: "f4", scale: "*0.001", dis: "Phase C Reactive Power" }
+      bacnetAddr: BacnetAddr { addr: "AI21", dis: "Phase C Reactive Power" }
+    }
+    ElecAcTotalNetReactivePowerSensor {
+      modbusAddr: ModbusAddr { addr: "408623", encoding: "f4", scale: "*0.001", dis: "Total Reactive Power" }
+      bacnetAddr: BacnetAddr { addr: "AI22", dis: "Total Reactive Power" }
+    }
+    ElecAcPhaseNetApparentPowerSensor {
+      phase: "L1"
+      modbusAddr: ModbusAddr { addr: "408625", encoding: "f4", scale: "*0.001", dis: "Phase A Apparent Power" }
+      bacnetAddr: BacnetAddr { addr: "AI23", dis: "Phase A Apparent Power" }
+    }
+    ElecAcPhaseNetApparentPowerSensor {
+      phase: "L2"
+      modbusAddr: ModbusAddr { addr: "408627", encoding: "f4", scale: "*0.001", dis: "Phase B Apparent Power" }
+      bacnetAddr: BacnetAddr { addr: "AI24", dis: "Phase B Apparent Power" }
+    }
+    ElecAcPhaseNetApparentPowerSensor {
+      phase: "L3"
+      modbusAddr: ModbusAddr { addr: "408629", encoding: "f4", scale: "*0.001", dis: "Phase C Apparent Power" }
+      bacnetAddr: BacnetAddr { addr: "AI25", dis: "Phase C Apparent Power" }
+    }
+    ElecAcTotalNetApparentPowerSensor {
+      modbusAddr: ModbusAddr { addr: "408631", encoding: "f4", scale: "*0.001", dis: "Total Apparent Power" }
+      bacnetAddr: BacnetAddr { addr: "AI26", dis: "Total Apparent Power" }
+    }
+    ElecAcPhasePfSensor {
+      pfTrue
+      pfIec
+      phase: "L1"
+      modbusAddr: ModbusAddr { addr: "408633", encoding: "f4", dis: "Phase A Power Factor" }
+      bacnetAddr: BacnetAddr { addr: "AI27", dis: "Phase A Power Factor" }
+    }
+    ElecAcPhasePfSensor {
+      pfTrue
+      pfIec
+      phase: "L2"
+      modbusAddr: ModbusAddr { addr: "408635", encoding: "f4", dis: "Phase B Power Factor" }
+      bacnetAddr: BacnetAddr { addr: "AI28", dis: "Phase B Power Factor" }
+    }
+    ElecAcPhasePfSensor {
+      pfTrue
+      pfIec
+      phase: "L3"
+      modbusAddr: ModbusAddr { addr: "408637", encoding: "f4", dis: "Phase C Power Factor" }
+      bacnetAddr: BacnetAddr { addr: "AI29", dis: "Phase C Power Factor" }
+    }
+    ElecAcTotalPfSensor {
+      pfTrue
+      pfIec
+      modbusAddr: ModbusAddr { addr: "408639", encoding: "f4", dis: "Total Power Factor" }
+      bacnetAddr: BacnetAddr { addr: "AI30", dis: "Total Power Factor" }
+    }
+    ElecAcLLAvgQualityVoltageSensor {
+      imbalance
+      modbusAddr: ModbusAddr { addr: "408641", encoding: "f4", scale: "*100", dis: "Voltage Unbalance" }
+      bacnetAddr: BacnetAddr { addr: "AI31", dis: "Voltage Unbalance Factor" }
+    }
+    ElecAcLAvgQualityCurrentSensor {
+      imbalance
+      modbusAddr: ModbusAddr { addr: "408643", encoding: "f4", scale: "*100", dis: "Current Unbalance" }
+      bacnetAddr: BacnetAddr { addr: "AI32", dis: "Current Unbalance Factor" }
+    }
+    ElecAcTotalNetActiveDemandSensor {
+      modbusAddr: ModbusAddr { addr: "408647", encoding: "f4", scale: "*0.001", dis: "Power Demand" }
+      bacnetAddr: BacnetAddr { addr: "AI34", dis: "Active Power Demand" }
+    }
+    ElecAcTotalNetReactiveDemandSensor {
+      modbusAddr: ModbusAddr { addr: "408649", encoding: "f4", scale: "*0.001", dis: "Reactive Power Demand" }
+      bacnetAddr: BacnetAddr { addr: "AI35", dis: "Reactive Power Demand" }
+    }
+    ElecAcTotalNetApparentDemandSensor {
+      modbusAddr: ModbusAddr { addr: "408651", encoding: "f4", scale: "*0.001", dis: "Apparent Power Demand" }
+      bacnetAddr: BacnetAddr { addr: "AI36", dis: "Apparent Power Demand" }
+    }
+    ElecAcPhaseNetCurrentDemandSensor {
+      phase: "L1"
+      modbusAddr: ModbusAddr { addr: "408653", encoding: "f4", dis: "Phase A Current Demand" }
+      bacnetAddr: BacnetAddr { addr: "AI37", dis: "Phase A Current Demand" }
+    }
+    ElecAcPhaseNetCurrentDemandSensor {
+      phase: "L2"
+      modbusAddr: ModbusAddr { addr: "408655", encoding: "f4", dis: "Phase B Current Demand" }
+      bacnetAddr: BacnetAddr { addr: "AI38", dis: "Phase B Current Demand" }
+    }
+    ElecAcPhaseNetCurrentDemandSensor {
+      phase: "L3"
+      modbusAddr: ModbusAddr { addr: "408657", encoding: "f4", dis: "Phase C Current Demand" }
+      bacnetAddr: BacnetAddr { addr: "AI39", dis: "Phase C Current Demand" }
+    }
+    ElecAcTotalImportActiveEnergySensor {
+      modbusAddr: ModbusAddr { addr: "408321", encoding: "u4", scale: "*0.001", dis: "Import Active Energy" }
+      bacnetAddr: BacnetAddr { addr: "AI40", dis: "Import Active Energy" }
+    }
+    ElecAcTotalExportActiveEnergySensor {
+      modbusAddr: ModbusAddr { addr: "408323", encoding: "u4", scale: "*0.001", dis: "Export Active Energy" }
+      bacnetAddr: BacnetAddr { addr: "AI41", dis: "Export Active Energy" }
+    }
+    ElecAcTotalImportReactiveEnergySensor {
+      modbusAddr: ModbusAddr { addr: "408337", encoding: "u4", scale: "*0.001", dis: "Import Reactive Energy" }
+      bacnetAddr: BacnetAddr { addr: "AI42", dis: "Import Reactive Energy" }
+    }
+    ElecAcTotalExportReactiveEnergySensor {
+      modbusAddr: ModbusAddr { addr: "408339", encoding: "u4", scale: "*0.001", dis: "Export Reactive Energy" }
+      bacnetAddr: BacnetAddr { addr: "AI43", dis: "Export Reactive Energy" }
+    }
+    ElecAcTotalNetActiveEnergySensor {
+      modbusAddr: ModbusAddr { addr: "408327", encoding: "u4", scale: "*0.001", dis: "Net Active Energy" }
+      bacnetAddr: BacnetAddr { addr: "AI45", dis: "Energy Net" }
+    }
+    ElecAcTotalNetReactiveEnergySensor {
+      modbusAddr: ModbusAddr { addr: "408343", encoding: "u4", scale: "*0.001", dis: "Net Reactive Energy" }
+      bacnetAddr: BacnetAddr { addr: "AI47", dis: "Reactive Energy Net" }
+    }
+    ElecAcTotalNetApparentEnergySensor {
+      modbusAddr: ModbusAddr { addr: "408357", encoding: "u4", scale: "*0.001", dis: "Total Apparent Energy" }
+      bacnetAddr: BacnetAddr { addr: "AI48", dis: "Apparent Energy" }
+    }
+    ElecAcPhaseImportActiveEnergySensor {
+      phase: "L1"
+      modbusAddr: ModbusAddr { addr: "408369", encoding: "u4", scale: "*0.001", dis: "Phase A Import Active Energy" }
+      bacnetAddr: BacnetAddr { addr: "AI49", dis: "Phase A Import Active Energy" }
+    }
+    ElecAcPhaseExportActiveEnergySensor {
+      phase: "L1"
+      modbusAddr: ModbusAddr { addr: "408371", encoding: "u4", scale: "*0.001", dis: "Phase A Export Active Energy" }
+      bacnetAddr: BacnetAddr { addr: "AI50", dis: "Phase A Export Active Energy" }
+    }
+    ElecAcPhaseImportActiveEnergySensor {
+      phase: "L2"
+      modbusAddr: ModbusAddr { addr: "408373", encoding: "u4", scale: "*0.001", dis: "Phase B Import Active Energy" }
+      bacnetAddr: BacnetAddr { addr: "AI51", dis: "Phase B Import Active Energy" }
+    }
+    ElecAcPhaseExportActiveEnergySensor {
+      phase: "L2"
+      modbusAddr: ModbusAddr { addr: "408375", encoding: "u4", scale: "*0.001", dis: "Phase B Export Active Energy" }
+      bacnetAddr: BacnetAddr { addr: "AI52", dis: "Phase B Export Active Energy" }
+    }
+    ElecAcPhaseImportActiveEnergySensor {
+      phase: "L3"
+      modbusAddr: ModbusAddr { addr: "408377", encoding: "u4", scale: "*0.001", dis: "Phase C Import Active Energy" }
+      bacnetAddr: BacnetAddr { addr: "AI53", dis: "Phase C Import Active Energy" }
+    }
+    ElecAcPhaseExportActiveEnergySensor {
+      phase: "L3"
+      modbusAddr: ModbusAddr { addr: "408379", encoding: "u4", scale: "*0.001", dis: "Phase C Export Active Energy" }
+      bacnetAddr: BacnetAddr { addr: "AI54", dis: "Phase C Export Active Energy" }
+    }
+    ElecAcPhaseImportReactiveEnergySensor {
+      phase: "L1"
+      modbusAddr: ModbusAddr { addr: "408381", encoding: "u4", scale: "*0.001", dis: "Phase A Import Reactive Energy" }
+      bacnetAddr: BacnetAddr { addr: "AI55", dis: "Phase A Import Reactive Energy" }
+    }
+    ElecAcPhaseExportReactiveEnergySensor {
+      phase: "L1"
+      modbusAddr: ModbusAddr { addr: "408383", encoding: "u4", scale: "*0.001", dis: "Phase A Export Reactive Energy" }
+      bacnetAddr: BacnetAddr { addr: "AI56", dis: "Phase A Export Reactive Energy" }
+    }
+    ElecAcPhaseImportReactiveEnergySensor {
+      phase: "L2"
+      modbusAddr: ModbusAddr { addr: "408385", encoding: "u4", scale: "*0.001", dis: "Phase B Import Reactive Energy" }
+      bacnetAddr: BacnetAddr { addr: "AI57", dis: "Phase B Import Reactive Energy" }
+    }
+    ElecAcPhaseExportReactiveEnergySensor {
+      phase: "L2"
+      modbusAddr: ModbusAddr { addr: "408387", encoding: "u4", scale: "*0.001", dis: "Phase B Export Reactive Energy" }
+      bacnetAddr: BacnetAddr { addr: "AI58", dis: "Phase B Export Reactive Energy" }
+    }
+    ElecAcPhaseImportReactiveEnergySensor {
+      phase: "L3"
+      modbusAddr: ModbusAddr { addr: "408389", encoding: "u4", scale: "*0.001", dis: "Phase C Import Reactive Energy" }
+      bacnetAddr: BacnetAddr { addr: "AI59", dis: "Phase C Import Reactive Energy" }
+    }
+    ElecAcPhaseExportReactiveEnergySensor {
+      phase: "L3"
+      modbusAddr: ModbusAddr { addr: "408391", encoding: "u4", scale: "*0.001", dis: "Phase C Export Reactive Energy" }
+      bacnetAddr: BacnetAddr { addr: "AI60", dis: "Phase C Export Reactive Energy" }
+    }
+    ElecAcPhaseImportApparentEnergySensor {
+      phase: "L1"
+      modbusAddr: ModbusAddr { addr: "408393", encoding: "u4", scale: "*0.001", dis: "Phase A Import Apparent Energy" }
+      bacnetAddr: BacnetAddr { addr: "AI61", dis: "Phase A Apparent Energy" }
+    }
+    ElecAcPhaseImportApparentEnergySensor {
+      phase: "L2"
+      modbusAddr: ModbusAddr { addr: "408397", encoding: "u4", scale: "*0.001", dis: "Phase B Import Apparent Energy" }
+      bacnetAddr: BacnetAddr { addr: "AI62", dis: "Phase B Apparent Energy" }
+    }
+    ElecAcPhaseImportApparentEnergySensor {
+      phase: "L3"
+      modbusAddr: ModbusAddr { addr: "408401", encoding: "u4", scale: "*0.001", dis: "Phase C Import Apparent Energy" }
+      bacnetAddr: BacnetAddr { addr: "AI63", dis: "Phase C Apparent Energy" }
+    }
+    ElecAcPhaseQualityCurrentSensor {
+      totalHarmonicDistortion
+      phase: "L1"
+      modbusAddr: ModbusAddr { addr: "416479", encoding: "s2", scale: "*0.01", dis: "THD_I1" }
+      bacnetAddr: BacnetAddr { addr: "AI68", dis: "Phase A Current THD" }
+    }
+    ElecAcPhaseQualityCurrentSensor {
+      totalHarmonicDistortion
+      phase: "L2"
+      modbusAddr: ModbusAddr { addr: "416480", encoding: "s2", scale: "*0.01", dis: "THD_I2" }
+      bacnetAddr: BacnetAddr { addr: "AI69", dis: "Phase B Current THD" }
+    }
+    ElecAcPhaseQualityCurrentSensor {
+      totalHarmonicDistortion
+      phase: "L3"
+      modbusAddr: ModbusAddr { addr: "416481", encoding: "s2", scale: "*0.01", dis: "THD_I3" }
+      bacnetAddr: BacnetAddr { addr: "AI70", dis: "Phase C Current THD" }
+    }
+    ElecAcLAvgQualityCurrentSensor {
+      totalHarmonicDistortion
+      modbusAddr: ModbusAddr { addr: "416482", encoding: "s2", scale: "*0.01", dis: "THD_Iavg" }
+      bacnetAddr: BacnetAddr { addr: "AI71", dis: "Average Current THD" }
+    }
+  }
+}

--- a/src/xeto/cc.accuenergy.acuvim_l/lib.xeto
+++ b/src/xeto/cc.accuenergy.acuvim_l/lib.xeto
@@ -1,0 +1,22 @@
+pragma: Lib <
+  doc: "Device models for Accuenergy's Acuvim-L Series"
+  version: "0.2.0"
+  depends: {
+    { lib: "sys" }
+    { lib: "sys.files" }
+    { lib: "ph" }
+    { lib: "ph.attrs" }
+    { lib: "ph.points" }
+    { lib: "ph.elec" }
+    { lib: "ph.protocols" }
+  }
+  license: "AFL-3.0"
+  org: {
+    dis: "Project Haystack"
+    uri: "https://project-haystack.org/"
+  }
+  vcs: {
+    type: "git"
+    uri:  "https://github.com/Project-Haystack/xeto-cc.git"
+  }
+>

--- a/src/xeto/cc.accuenergy.acuvim_l/misc.xeto
+++ b/src/xeto/cc.accuenergy.acuvim_l/misc.xeto
@@ -1,0 +1,27 @@
+//
+// Copyright (c) 2026, Project-Haystack
+// Licensed under the Academic Free License version 3.0
+//
+// History:
+//   19 Jun 2026  Rick Jennings  Creation
+//
+
+ElecAcMeter : AcElecMeter
+
+// An AC electric meter that uses 3 line-to-neutral voltage channels.
+ElecAc3LNMeter: ElecAcMeter
+
+// An AC electric meter that uses 3 line-to-line voltage channels.
+ElecAc3LLMeter: ElecAcMeter
+
+// An AC electric meter that uses 2 line-to-line voltage channels.
+ElecAc2LLMeter: ElecAcMeter
+
+// An AC electric meter that uses 1 line-to-line voltage channel.
+ElecAc1LLMeter: ElecAcMeter
+
+// An AC electric meter that uses 1 line-to-neutral voltage channel.
+ElecAc1LNMeter: ElecAcMeter
+
+// An AC electric meter that uses 2 line-to-neutral voltage channels.
+ElecAc2LNMeter: ElecAcMeter

--- a/src/xeto/cc.accuenergy.acuvim_l/readme.md
+++ b/src/xeto/cc.accuenergy.acuvim_l/readme.md
@@ -1,0 +1,64 @@
+# cc.accuenergy.acuvim_l
+
+Device models for Accuenergy's Acuvim-L Series multifunction power and energy
+meters.
+
+Reference: Acuvim-L Multifunction Power and Energy Meter User Manual v4.
+
+## Supported Models
+
+The Acuvim-L Series covers two models that share the same Modbus register
+map and BACnet object list:
+
+- **Acuvim-EL**: 0.2% accuracy class (ANSI C12.20 / IEC 62053-22 class 0.5S),
+  harmonic measurement to the 63rd order, adds time-of-use (TOU) tariff
+  support
+- **Acuvim-CL**: 0.5% accuracy class, harmonic measurement to the 31st order
+
+The series-level `AcuvimL*` specs are abstract; model-specific concrete
+specs inherit from them. Currently only Acuvim-EL concrete specs are
+defined (`AcuvimEL*`); Acuvim-CL specs are planned future work.
+
+## Wiring Configurations
+
+The meter supports five voltage wiring modes (register 1003H): 3LN, 1LN,
+2LL, 3LL, and 1LL. The 3LN-2.5 element configuration uses the 3LN setting.
+The same Modbus registers are reused across wiring modes; in 2LL/3LL modes
+the voltage THD registers report line-to-line THD (V12, V31, V23) rather
+than phase THD, so the voltage THD points are modeled on wiring-specific
+abstract types:
+
+- `AcuvimLElecAc1LNOr1LLOr3LNMeter`: phase voltage THD
+- `AcuvimLElecAc2LLOr3LLMeter`: line-to-line voltage THD
+
+Abstract series-level wiring types: `AcuvimLElecAc3LNMeter`,
+`AcuvimLElecAc1LNMeter`, `AcuvimLElecAc1LLMeter`, `AcuvimLElecAc3LLMeter`,
+`AcuvimLElecAc2LLMeter`.
+
+Concrete Acuvim-EL types: `AcuvimELElecAc3LNMeter`, `AcuvimELElecAc1LNMeter`,
+`AcuvimELElecAc1LLMeter`, `AcuvimELElecAc3LLMeter`, `AcuvimELElecAc2LLMeter`.
+
+## Configuration Assumptions
+
+Point scale factors assume the following meter settings:
+
+- Real-Time Reading mode (register 101DH) set to Primary; values include
+  PT/CT ratios with no external multiplier
+- Energy Display mode (register 1019H) set to Secondary or Primary 0.01kWh;
+  energy registers convert with Rx/1000 (`*0.001` scale)
+- Power factor convention IEC (register 1015H, factory default)
+- Energy calculating mode Full, so power factor points are true power factor
+
+## Omitted BACnet Objects
+
+- AI33 Load Type: reports an ASCII character code (R/L/C), not a sensor value
+- AI44 Energy Total and AI46 Reactive Energy Total: import plus export sums
+- Per-phase export apparent energy registers have no BACnet objects; AI61-63
+  expose the per-phase import apparent energy registers
+
+## Omitted Modbus Registers
+
+- In_measure (Modicon 408603): measured neutral current, only meaningful on
+  units with a neutral CT input; no BACnet object
+- Itotal (Modicon 408605): sum of phase currents; no BACnet object and no
+  corresponding ph.elec sensor flavor


### PR DESCRIPTION
Adds `cc.accuenergy.acuvim_l`, device models for Accuenergy's Acuvim-L Series multifunction power and energy meters (Acuvim-EL and Acuvim-CL share the same register map).

## Structure

- `AcuvimLElecAcMeter` abstract base with all wiring-agnostic points (65 points: real-time, demand, energy, current THD)
- Wiring-subset abstracts per the elec meter skill: `AcuvimLElecAc1LNOr1LLOr3LNMeter` (phase voltage THD) and `AcuvimLElecAc2LLOr3LLMeter` (line-to-line voltage THD)
- Abstract series-level wiring specs (`AcuvimLElecAc3LNMeter`, `1LN`, `1LL`, `3LL`, `2LL`) extending the generic `ElecAcXXMeter` wiring specs from `misc.xeto`
- Concrete Acuvim-EL specs (`AcuvimELElecAc3LNMeter`, etc.) inheriting from the series abstracts; Acuvim-CL specs deferred as future work

## Verification

- All Modbus registers, encodings, and scales verified against Acuvim-L User Manual v4 (Tables 6-19 Real-Time, 6-20 Energy, 6-27 THD)
- Modbus addrs in 6-digit Modicon notation with scale exprs, consistent with `cc.accuenergy.acuvim2`
- Configuration assumptions (Primary reading mode, Rx/1000 energy conversion, IEC PF convention) and omitted registers/BACnet objects documented in the readme